### PR TITLE
Added SparkSQL support based on HiveDialect

### DIFF
--- a/pyhive/sqlalchemy_sparksql.py
+++ b/pyhive/sqlalchemy_sparksql.py
@@ -1,0 +1,70 @@
+from . import sqlalchemy_hive
+
+import re
+
+from sqlalchemy import exc
+from sqlalchemy.engine import default
+
+
+class SparkSqlDialect(sqlalchemy_hive.HiveDialect):
+    name = b'sparksql'
+    execution_ctx_cls = default.DefaultExecutionContext
+
+    def _get_table_columns(self, connection, table_name, schema):
+        full_table = table_name
+        if schema:
+            full_table = schema + '.' + table_name
+        # TODO using TGetColumnsReq hangs after sending TFetchResultsReq.
+        # Using DESCRIBE works but is uglier.
+        try:
+            # This needs the table name to be unescaped (no backticks).
+            rows = connection.execute('DESCRIBE {}'.format(full_table)).fetchall()
+        except exc.OperationalError as e:
+            # Does the table exist?
+            regex_fmt = r'TExecuteStatementResp.*NoSuchTableException.*Table or view \'{}\' not found'
+            regex = regex_fmt.format(re.escape(table_name))
+            if re.search(regex, e.args[0]):
+                raise exc.NoSuchTableError(full_table)
+            elif schema:
+                schema_regex_fmt = r'TExecuteStatementResp.*NoSuchDatabaseException.*Database \'{}\' not found'
+                schema_regex = schema_regex_fmt.format(re.escape(schema))
+                if re.search(schema_regex, e.args[0]):
+                    raise exc.NoSuchTableError(full_table)
+            else:
+                # When a hive-only column exists in a table
+                hive_regex_fmt = r'org.apache.spark.SparkException: Cannot recognize hive type string'
+                if re.search(hive_regex_fmt, e.args[0]):
+                    raise exc.UnreflectableTableError
+                else:
+                    raise
+        else:
+            return rows
+
+    def get_table_names(self, connection, schema=None, **kw):
+        query = 'SHOW TABLES'
+        if schema:
+            query += ' IN ' + self.identifier_preparer.quote_identifier(schema)
+        return list(row[1] for row in filter(
+            lambda x: not x[-1],
+            [row for row in connection.execute(query)]
+        ))
+
+    def get_view_names(self, connection, schema=None, **kw):
+        query = 'SHOW TABLES'
+        if schema:
+            query += ' IN ' + self.identifier_preparer.quote_identifier(schema)
+        return list(row[1] for row in filter(
+            lambda x: x[-1],
+            [row for row in connection.execute(query)]
+        ))
+
+    def has_table(self, connection, table_name, schema=None):
+        try:
+            self._get_table_columns(connection, table_name, schema)
+            return True
+        except exc.NoSuchTableError:
+            return False
+        except exc.UnreflectableTableError:
+            return False
+
+

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
         'sqlalchemy.dialects': [
             'hive = pyhive.sqlalchemy_hive:HiveDialect',
             'presto = pyhive.sqlalchemy_presto:PrestoDialect',
+            'sparksql = pyhive.sqlalchemy_sparksql:SparkSqlDialect',
         ],
     }
 )


### PR DESCRIPTION
SparkSQL is made to be almost compatible with HiveQL. However, the
`show tables` syntax for Spark SQL is slightly different. As such, a new
SparkSQL dialect is created based on the original HiveDialect with
`get_table_names` modified to accommodate the results returned from Spark SQL's
'SHOW TABLES'.